### PR TITLE
Update dependencies and GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -45,6 +45,6 @@ jobs:
       run: ./gradlew assemble
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     
     - name: Build and export
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: .
         load: true
@@ -40,7 +40,7 @@ jobs:
     
     - name: Build and push (on main branch only)
       if: github.ref == 'refs/heads/main'
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
         grep -A3 "CodeNarc" build.gradle
     
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v3
+      uses: mikepenz/action-junit-report@v5
       if: always()
       with:
         report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -28,7 +28,7 @@ jobs:
       run: ./gradlew assembleDist
     
     - name: Upload Release Asset
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           build/distributions/jenkins-script-library-*.zip
@@ -36,7 +36,7 @@ jobs:
           build/libs/jenkins-script-library-*.jar
         
     - name: Build and push Docker image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     implementation 'org.codehaus.groovy:groovy-all:2.4.21'
     
     // Standard dependencies
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.24.3'
+    implementation 'org.apache.logging.log4j:log4j-core:2.24.3'
     
     // Jenkins dependencies - marked as provided since they're provided by Jenkins
     compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
@@ -52,7 +52,7 @@ dependencies {
     compileOnly 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.24'
     
     // Unit test dependencies
-    testImplementation 'org.mockito:mockito-core:4.11.0'
+    testImplementation 'org.mockito:mockito-core:5.17.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.4' // Spock for Groovy 2.4
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
@@ -66,7 +66,7 @@ dependencies {
     
     // Integration test dependencies for running real Jenkins tests
     integrationTestImplementation 'org.jenkins-ci.main:jenkins-test-harness:2.72'
-    integrationTestImplementation 'org.jenkins-ci:test-annotations:1.3'
+    integrationTestImplementation 'org.jenkins-ci:test-annotations:1.5'
     integrationTestImplementation 'org.jenkins-ci.main:jenkins-core:2.361.1'
     integrationTestImplementation 'org.jenkins-ci.plugins:credentials:2.6.1'
     integrationTestImplementation 'org.jenkins-ci.plugins:matrix-auth:3.2.6'


### PR DESCRIPTION
This PR updates all dependencies and GitHub Actions to their latest versions to ensure compatibility and security. All Dependabot PRs have been consolidated into a single PR to simplify the merge process.

Updates include:
- Update log4j-api and log4j-core from 2.20.0 to 2.24.3
- Update mockito-core from 4.11.0 to 5.17.0
- Update test-annotations from 1.3 to 1.5
- Update GitHub Actions to latest versions:
  - actions/checkout@v4
  - actions/setup-java@v4
  - github/codeql-action@v3
  - docker/setup-qemu-action@v3
  - docker/setup-buildx-action@v3
  - docker/build-push-action@v6
  - softprops/action-gh-release@v2
  - mikepenz/action-junit-report@v5

This PR resolves all open Dependabot PRs.