### PR TITLE
Add pipeline generation utilities and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A collection of Groovy utilities and scripts designed to automate and facilitate
 - **Security**: Audit and secure Jenkins instances
 - **Performance Optimization**: Monitor and improve Jenkins performance
 - **Configuration Management**: Backup and restore Jenkins configurations
+- **Pipeline Generation**: Create Jenkins pipelines from reusable templates
 
 ## Project Structure
 
@@ -30,9 +31,9 @@ jenkins-script-library/
 │   │   └── com/github/thomasvincent/jenkinsscripts/
 │   │       ├── cloud/          # Cloud provider integrations
 │   │       ├── config/         # Configuration management
-│   │       ├── helm/           # Helm management 
-│   │       ├── jobs/           # Job management 
-│   │       ├── nodes/          # Node management 
+│   │       ├── helm/           # Helm management
+│   │       ├── jobs/           # Job management
+│   │       ├── nodes/          # Node management
 │   │       ├── scripts/        # Command-line script entry points
 │   │       ├── security/       # Security utilities
 │   │       └── util/           # Common utilities
@@ -53,7 +54,7 @@ jenkins-script-library/
 This library can be used in two ways:
 
 1. **As a dependency in your Gradle/Maven project**:
-   
+
    ```groovy
    // In your build.gradle
    dependencies {
@@ -62,7 +63,7 @@ This library can be used in two ways:
    ```
 
 2. **As individual scripts to run directly in Jenkins**:
-   
+
    The scripts in `src/main/groovy/com/github/thomasvincent/jenkinsscripts/scripts/` can be executed directly in Jenkins Script Console or through the Jenkins CLI.
 
 ## Usage
@@ -108,6 +109,16 @@ groovy MigrateJobs.groovy --url https://target-jenkins.example.com --user admin 
 # Create a job from a template
 groovy CreateJobFromTemplate.groovy --template-job template-job --target-job new-job --params-file params.json
 ```
+##### Pipeline Generation
+```groovy
+// Generate a Jenkinsfile from template
+generatePipeline(
+    template: 'templates/basic-pipeline.jenkinsfile',
+    parameters: [project: 'my-app'],
+    destination: 'Jenkinsfile'
+)
+```
+
 
 ##### Job Analysis
 ```bash

--- a/src/main/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGenerator.groovy
+++ b/src/main/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGenerator.groovy
@@ -34,9 +34,8 @@ class PipelineGenerator {
         return result.toString()
     }
 
-    boolean writeToFile(File destination, Map params = [:]) {
+    void writeToFile(File destination, Map params = [:]) {
         ValidationUtils.requireNonNull(destination, 'Destination file')
         destination.setText(generate(params), 'UTF-8')
-        return true
     }
 }

--- a/src/main/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGenerator.groovy
+++ b/src/main/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGenerator.groovy
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2025 Thomas Vincent
+ */
+
+package com.github.thomasvincent.jenkinsscripts.pipeline
+
+import groovy.text.SimpleTemplateEngine
+import com.github.thomasvincent.jenkinsscripts.util.ValidationUtils
+
+/**
+ * Generates Jenkins pipeline scripts from templates.
+ *
+ * Usage:
+ * def generator = new PipelineGenerator(templateText)
+ * def script = generator.generate([project: 'demo'])
+ */
+class PipelineGenerator {
+    private final String template
+
+    PipelineGenerator(String template) {
+        this.template = ValidationUtils.requireNonEmpty(template, 'Template')
+    }
+
+    static PipelineGenerator fromFile(File templateFile) {
+        ValidationUtils.requireNonNull(templateFile, 'Template file')
+        return new PipelineGenerator(templateFile.getText('UTF-8'))
+    }
+
+    String generate(Map params = [:]) {
+        def engine = new SimpleTemplateEngine()
+        def result = engine.createTemplate(template).make(params ?: [:])
+        return result.toString()
+    }
+
+    boolean writeToFile(File destination, Map params = [:]) {
+        ValidationUtils.requireNonNull(destination, 'Destination file')
+        destination.setText(generate(params), 'UTF-8')
+        return true
+    }
+}

--- a/src/test/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGeneratorSpec.groovy
+++ b/src/test/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGeneratorSpec.groovy
@@ -1,0 +1,36 @@
+package com.github.thomasvincent.jenkinsscripts.pipeline
+
+import spock.lang.Specification
+import spock.lang.Title
+
+@Title("PipelineGenerator Specification")
+class PipelineGeneratorSpec extends Specification {
+
+    def "generates pipeline with parameters"() {
+        given:
+        String template = "pipeline { stages { stage('Build'){ steps { echo \"${project}\" } } } }"
+        def generator = new PipelineGenerator(template)
+
+        when:
+        String result = generator.generate([project: 'demo'])
+
+        then:
+        result.contains('echo "demo"')
+    }
+
+    def "writes generated pipeline to file"() {
+        given:
+        String template = 'pipeline { agent any }'
+        def generator = new PipelineGenerator(template)
+        File tempFile = File.createTempFile('pipeline', '.jenkinsfile')
+
+        when:
+        generator.writeToFile(tempFile)
+
+        then:
+        tempFile.text.contains('pipeline { agent any }')
+
+        cleanup:
+        tempFile.delete()
+    }
+}

--- a/templates/basic-pipeline.jenkinsfile
+++ b/templates/basic-pipeline.jenkinsfile
@@ -1,0 +1,11 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Build') {
+            steps {
+                echo "Building ${project}"
+            }
+        }
+    }
+}

--- a/vars/generatePipeline.groovy
+++ b/vars/generatePipeline.groovy
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2025 Thomas Vincent
+ */
+
+import com.github.thomasvincent.jenkinsscripts.pipeline.PipelineGenerator
+
+/**
+ * Generates a Jenkins pipeline script from a template.
+ *
+ * Example:
+ * ```groovy
+ * generatePipeline(
+ *     template: 'templates/basic-pipeline.jenkinsfile',
+ *     parameters: [project: 'demo'],
+ *     destination: 'Jenkinsfile'
+ * )
+ * ```
+ *
+ * @param template Path to template file or template text
+ * @param parameters Map of template parameters
+ * @param destination Optional file path to write the generated script
+ * @return Generated pipeline script
+ */
+def call(Map args = [:]) {
+    String template = args.template
+    Map params = args.parameters ?: [:]
+    String destination = args.destination
+
+    if (!template) {
+        error 'template parameter is required'
+    }
+
+    String templateText
+    if (fileExists(template)) {
+        templateText = readFile(template)
+    } else {
+        templateText = template
+    }
+
+    def generator = new PipelineGenerator(templateText)
+    String script = generator.generate(params)
+
+    if (destination) {
+        writeFile file: destination, text: script
+    }
+
+    return script
+}


### PR DESCRIPTION
## Summary
- add PipelineGenerator class for rendering Jenkinsfile templates
- expose generatePipeline shared library step
- document and provide a basic pipeline template

## Testing
- `pre-commit run --files src/main/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGenerator.groovy vars/generatePipeline.groovy templates/basic-pipeline.jenkinsfile src/test/groovy/com/github/thomasvincent/jenkinsscripts/pipeline/PipelineGeneratorSpec.groovy README.md` *(fails: Task 'codenarcMain' not found; credential-check and groovy-syntax hooks errors)*
- `./gradlew test` *(fails: Could not determine the dependencies of task ':test' – missing Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68952fd77e688327b9cd41f1d2c93762