### PR TITLE
Handle null exceptions in ErrorHandler

### DIFF
--- a/src/main/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandler.groovy
+++ b/src/main/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandler.groovy
@@ -29,21 +29,21 @@ import java.util.logging.Logger
 
 /**
  * Provides standardized error handling for Jenkins scripts.
- * 
+ *
  * This utility centralizes error handling logic to ensure:
  * - Consistent error reporting
  * - Proper logging with appropriate log levels
  * - Helpful user-facing error messages
- * 
+ *
  * @author Thomas Vincent
  * @since 1.1.0
  */
 class ErrorHandler {
-    
+
     /**
      * Handles an exception consistently, logging it with the appropriate level.
-     * 
-     * @param operation Description of the operation that failed 
+     *
+     * @param operation Description of the operation that failed
      * @param e The exception to handle
      * @param logger The logger to use
      * @param level Optional log level (defaults to SEVERE)
@@ -52,13 +52,13 @@ class ErrorHandler {
         String errorMessage = formatErrorMessage(operation, e)
         logger.log(level, errorMessage, e)
     }
-    
+
     /**
      * Handles an exception and returns a default value.
-     * 
+     *
      * Use this method in cases where the operation should continue despite the error,
      * but with a fallback value.
-     * 
+     *
      * @param operation Description of the operation that failed
      * @param e The exception to handle
      * @param logger The logger to use
@@ -72,10 +72,10 @@ class ErrorHandler {
         logger.log(level, errorMessage, e)
         return defaultValue
     }
-    
+
     /**
      * Wraps an operation with standard error handling.
-     * 
+     *
      * @param operation Description of the operation
      * @param action The closure to execute
      * @param logger The logger to use
@@ -95,24 +95,31 @@ class ErrorHandler {
             }
         }
     }
-    
+
     /**
      * Formats an error message for consistent presentation.
-     * 
+     *
      * @param operation Description of the operation that failed
      * @param e The exception that occurred
      * @return Formatted error message
      */
-    private static String formatErrorMessage(String operation, Exception e) {
+    static String formatErrorMessage(String operation, Exception e) {
         StringBuilder errorMessage = new StringBuilder()
-        errorMessage.append("Error during ${operation}: ${e.message}")
-        
+        if (operation) {
+            errorMessage.append("Error during ${operation}")
+        } else {
+            errorMessage.append("Error")
+        }
+        if (e?.message) {
+            errorMessage.append(": ${e.message}")
+        }
+
         // Add root cause if available
-        Throwable cause = e.cause
+        Throwable cause = e?.cause
         if (cause && cause != e) {
             errorMessage.append(" (Caused by: ${cause.class.simpleName}: ${cause.message})")
         }
-        
+
         return errorMessage.toString()
     }
 }

--- a/src/main/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandler.groovy
+++ b/src/main/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandler.groovy
@@ -117,7 +117,7 @@ class ErrorHandler {
         // Add root cause if available
         Throwable cause = e?.cause
         if (cause && cause != e) {
-            errorMessage.append(" (Caused by: ${cause.class.simpleName}: ${cause.message})")
+            errorMessage.append(" (Caused by: ${cause.class.simpleName}: ${cause.message ?: 'No message'})")
         }
 
         return errorMessage.toString()

--- a/src/test/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandlerSpec.groovy
+++ b/src/test/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandlerSpec.groovy
@@ -15,24 +15,24 @@ import java.util.logging.LogRecord
 @Title("ErrorHandler Specification")
 @Subject(ErrorHandler)
 class ErrorHandlerSpec extends Specification {
-    
+
     Logger testLogger
     TestLogHandler logHandler
-    
+
     def setup() {
         testLogger = Logger.getLogger("TestLogger")
         logHandler = new TestLogHandler()
         testLogger.addHandler(logHandler)
         testLogger.useParentHandlers = false
     }
-    
+
     def "handleError logs error with correct level and message"() {
         given: "an exception"
         def exception = new RuntimeException("Test error")
-        
+
         when: "handling the error"
         ErrorHandler.handleError("Test operation failed", exception, testLogger, Level.SEVERE)
-        
+
         then: "log contains correct information"
         logHandler.records.size() == 1
         with(logHandler.records[0]) {
@@ -42,16 +42,16 @@ class ErrorHandlerSpec extends Specification {
             thrown == exception
         }
     }
-    
+
     def "handleErrorWithDefault returns default value and logs warning"() {
         given: "an exception and default value"
         def exception = new RuntimeException("Test error")
         def defaultValue = "default"
-        
+
         when: "handling error with default"
         def result = ErrorHandler.handleErrorWithDefault(
             "Test operation failed", exception, testLogger, defaultValue, Level.WARNING)
-        
+
         then: "returns default and logs warning"
         result == defaultValue
         logHandler.records.size() == 1
@@ -62,24 +62,24 @@ class ErrorHandlerSpec extends Specification {
             thrown == exception
         }
     }
-    
+
     def "withErrorHandling returns result on success"() {
         when: "operation succeeds"
-        def result = ErrorHandler.withErrorHandling("Test operation", { 
-            "success" 
+        def result = ErrorHandler.withErrorHandling("Test operation", {
+            "success"
         }, testLogger, "default")
-        
+
         then: "returns success value without logging"
         result == "success"
         logHandler.records.empty
     }
-    
+
     def "withErrorHandling returns default on exception"() {
         when: "operation throws exception"
-        def result = ErrorHandler.withErrorHandling("Test operation", { 
+        def result = ErrorHandler.withErrorHandling("Test operation", {
             throw new RuntimeException("Test error")
         }, testLogger, "default")
-        
+
         then: "returns default and logs error"
         result == "default"
         logHandler.records.size() == 1
@@ -89,46 +89,41 @@ class ErrorHandlerSpec extends Specification {
             thrown instanceof RuntimeException
         }
     }
-    
+
     @Unroll
     def "formatErrorMessage handles #scenario correctly"() {
         when: "formatting error message"
         def message = ErrorHandler.formatErrorMessage(operation, exception)
-        
+
         then: "message contains expected content"
         message != null
         if (operation) message.contains(operation)
         if (exceptionMessage) message.contains(exceptionMessage)
         if (causeMessage) message.contains(causeMessage)
-        
+
         where:
         scenario            | operation           | exception                                              | exceptionMessage | causeMessage
         "normal case"       | "Operation failed"  | new RuntimeException("Test error")                     | "Test error"     | null
         "with cause"        | "Operation failed"  | new RuntimeException("Test", new Exception("Cause"))   | "Test"           | "Cause"
         "null operation"    | null                | new RuntimeException("Test error")                     | "Test error"     | null
     }
-    
+
     def "formatErrorMessage handles null exception gracefully"() {
         when: "formatting with null exception"
-        def message
-        try {
-            message = ErrorHandler.formatErrorMessage("Operation failed", null)
-        } catch (NullPointerException e) {
-            message = null
-        }
-        
-        then: "either returns message or handles NPE"
-        message == null || message.contains("Operation failed")
+        def message = ErrorHandler.formatErrorMessage("Operation failed", null)
+
+        then: "returns message without throwing"
+        message.contains("Operation failed")
     }
-    
+
     // Helper class using Groovy property syntax
     private static class TestLogHandler extends Handler {
         List<LogRecord> records = []
-        
+
         void publish(LogRecord record) {
             records << record
         }
-        
+
         void flush() {}
         void close() {}
     }


### PR DESCRIPTION
## Summary
- make ErrorHandler.formatErrorMessage public and null-safe
- test ErrorHandler formatting with null exceptions

## Testing
- `./gradlew test`
- `SKIP=codenarc,credential-check,groovy-syntax pre-commit run --files src/main/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandler.groovy src/test/groovy/com/github/thomasvincent/jenkinsscripts/util/ErrorHandlerSpec.groovy`


------
https://chatgpt.com/codex/tasks/task_e_68953ec76c6083278d7e7655280a0aa3