### PR TITLE
fix(ci): pin Gradle test Java images

### DIFF
--- a/Dockerfile.java21
+++ b/Dockerfile.java21
@@ -3,7 +3,7 @@
 # This Dockerfile creates an environment for testing the Jenkins Script Library
 # with Java 21. It includes Gradle and all necessary testing tools.
 
-FROM eclipse-temurin:25-jdk
+FROM eclipse-temurin:21-jdk
 
 # Set environment variables
 ENV GRADLE_VERSION=8.14.2

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,10 +3,10 @@
 # This Dockerfile creates an environment for testing the Jenkins Script Library.
 # It includes Java 17, Gradle, and all necessary testing tools.
 
-FROM eclipse-temurin:25-jdk
+FROM eclipse-temurin:17-jdk
 
 # Set environment variables
-ENV GRADLE_VERSION=8.7
+ENV GRADLE_VERSION=8.14.2
 
 # Install required packages
 RUN apt-get update && apt-get install -y \
@@ -42,4 +42,3 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Default command runs the tests
 CMD ["./gradlew", "test", "--no-daemon"]
-


### PR DESCRIPTION
## Summary
- pin the Java 17 Docker test image to eclipse-temurin:17-jdk instead of the Java 25 image
- pin the Java 21 compatibility image to eclipse-temurin:21-jdk instead of the Java 25 image
- align the Java 17 test image's baked Gradle version with the wrapper version

## Validation
- docker compose -f docker-compose.test.yml build java17 java21
- docker compose -f docker-compose.test.yml run --rm ... java17 ./gradlew test --no-daemon
- docker compose -f docker-compose.test.yml run --rm ... java21 ./gradlew test --no-daemon
- docker compose -f docker-compose.test.yml run --rm ... java17 ./gradlew compileGroovy --info
- docker compose -f docker-compose.test.yml run --rm ... java17 ./gradlew codenarcMain codenarcTest --no-daemon

Note: local pre-commit was attempted, but the repo's custom credential-check hook failed with a shell quoting error before running against these Dockerfile-only changes.